### PR TITLE
adds simple cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ Create a new virtual environment (`uv venv --python 3.12`), then install depende
 
 You will then need to create a `.env` file. There is a sample file (`.env.sample`) which you can use as a template.
 Speak to colleagues to get the correct values.
+
+## Running from the command line
+
+If used with `uv` in the steps above, activate the venv, then you can run:
+
+- `nhp_aci run`
+- `nhp_aci status`
+- `nhp_aci clean`
+
+for each of these commands, append `-h` to see the usage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,6 @@ typeCheckingMode = "basic"
 
 [tool.setuptools_scm]
 version_file = "src/nhp/_version.py"
+
+[project.scripts]
+nhp_aci = "nhp.aci.__main__:main"

--- a/src/nhp/aci/__main__.py
+++ b/src/nhp/aci/__main__.py
@@ -1,0 +1,156 @@
+"""NHP ACI CLI.
+
+Provides command line interface tools for working with Azure Container Interfaces to run the model.
+"""
+
+import argparse
+import json
+
+from nhp.aci.clean_up import clean_up_model_run
+from nhp.aci.run_model import create_model_run
+from nhp.aci.status import get_current_model_runs, get_model_run_status
+
+
+def _arg_parser() -> argparse.ArgumentParser:
+    """Parse the command line arguments.
+
+    :returns: an ArgumentParser object containing the parsed command line arguments.
+    :rtype: argparse.ArgumentParser
+    """
+    parser = argparse.ArgumentParser(description="NHP Azure Container Instance CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Run model command
+    run_parser = subparsers.add_parser("run", help="Start a model run in ACI")
+    run_parser.add_argument("params", help="Path to model params JSON")
+    run_parser.add_argument(
+        "--app-version",
+        required=False,
+        default=None,
+        help="Model version (optional, defaults to whats inside the params, or 'dev')",
+    )
+    run_parser.add_argument(
+        "--dataset",
+        required=False,
+        default=None,
+        help="Dataset (optional, defaults to whats inside the params)",
+    )
+    run_parser.add_argument(
+        "--save-full-model-results", action="store_true", help="Save full model results"
+    )
+    run_parser.add_argument("--timeout", default="60m", help="Container timeout (default: 60m)")
+
+    # Status command
+    status_parser = subparsers.add_parser("status", help="Check container status")
+    status_parser.add_argument("model_id", nargs="?", help="Model run ID")
+
+    # Clean command
+    clean_parser = subparsers.add_parser("clean", help="Clean up model runs")
+    clean_parser.add_argument("model_id", help="Model run ID")
+
+    return parser
+
+
+def _run(args: argparse.Namespace) -> None:
+    """Run the model.
+
+    :param args: the parsed CLI arguments.
+    :type args: argparse.Namespace
+    """
+    # load the params
+    with open(args.params, "r", encoding="UTF-8") as f:
+        params = json.load(f)
+
+    # handle the app_version
+    app_version = args.app_version or params.get("app_version", "dev")
+    # push the app version back into the params, in case it has changed
+    params["app_version"] = app_version
+
+    # handle the dataset override
+    if args.dataset:
+        params["dataset"] = args.dataset
+
+    # create the model run
+    metadata = create_model_run(
+        params,
+        app_version,
+        args.save_full_model_results,
+        args.timeout,
+    )
+    print(f"Model run started: {metadata['id']}")
+
+
+def _status_single_model_run(model_id: str) -> None:
+    """Print the status of a single model run.
+
+    :param model_id: The model id to get the status of.
+    :type model_id: str
+    """
+    status = get_model_run_status(model_id)
+    if not status:
+        print(f"Unknown model id: {model_id}")
+        return
+
+    state = status["state"]
+
+    complete = status["complete"]
+    model_runs = status["model_runs"]
+    if complete["outpatients"] >= model_runs:
+        complete_str = f"aae: {complete['aae']}"
+    elif complete["inpatients"] >= model_runs:
+        complete_str = f"op: {complete['outpatients']}"
+    else:
+        complete_str = f"ip: {complete['inpatients']}"
+
+    print(f"{model_id}: {state} [{complete_str}/{model_runs}]")
+
+
+def _status_all_model_runs() -> None:
+    """Print the status of all of the current model runs."""
+    current_runs = get_current_model_runs()
+
+    if not current_runs:
+        print("There are currently no model runs")
+        return
+
+    print("Current Model Runs:")
+    for k, v in current_runs.items():
+        state = v["state"] if v else "unknown"
+        print(f"{k}: {state}")
+
+
+def _status(args: argparse.Namespace) -> None:
+    """Status subcommand.
+
+    :param args: the parsed CLI arguments.
+    :type args: argparse.Namespace
+    """
+    if args.model_id:
+        _status_single_model_run(args.model_id)
+    else:
+        _status_all_model_runs()
+
+
+def main() -> None:
+    """Main method."""
+    parser = _arg_parser()
+    args = parser.parse_args()
+
+    match args.command:
+        case "run":
+            _run(args)
+        case "status":
+            _status(args)
+        case "clean":
+            clean_up_model_run(args.model_id)
+        case _:
+            parser.print_help()
+
+
+def init() -> None:
+    """Init method."""
+    if __name__ == "__main__":
+        main()
+
+
+init()

--- a/src/nhp/aci/clean_up.py
+++ b/src/nhp/aci/clean_up.py
@@ -1,0 +1,83 @@
+"""Clean up ACI/blob resources."""
+
+from azure.core.credentials import TokenCredential
+from azure.core.exceptions import ResourceNotFoundError
+from azure.identity import DefaultAzureCredential
+from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+from azure.storage.blob import BlobServiceClient
+
+from nhp.aci.config import Config
+
+
+def _delete_blob_in_queue(
+    model_run_id: str,
+    credential: TokenCredential = DefaultAzureCredential(),
+    config: Config = Config.create_from_envvars(),
+) -> None:
+    """Delete params in queue.
+
+    Clean up a model run by deleting the params file in the queue.
+
+    :param model_run_id: The id of the model run to delete.
+    :type model_run_id: str
+    :param credential: Credential for authenticating with Azure,
+        defaults to DefaultAzureCredential()
+    :type credential: TokenCredential, optional
+    :param config: Configuration object, defaults to creating from envvars
+    :type config: Config, optional
+    """
+    filename = f"{model_run_id}.json"
+    bsc = BlobServiceClient(config.storage_endpoint, credential)
+    cont = bsc.get_container_client("queue")
+    try:
+        cont.delete_blob(filename)
+        print(f"Successfully deleted {filename} from queue")
+    except ResourceNotFoundError:
+        print(f"{filename} does not exist, potentially already removed")
+
+
+def _delete_container_group(
+    model_run_id: str,
+    credential: TokenCredential = DefaultAzureCredential(),
+    config: Config = Config.create_from_envvars(),
+) -> None:
+    """Delete container group.
+
+    Clean up a model run by deleting the compute resource in ACI.
+
+    :param model_run_id: The id of the model run to delete.
+    :type model_run_id: str
+    :param credential: Credential for authenticating with Azure,
+        defaults to DefaultAzureCredential()
+    :type credential: TokenCredential, optional
+    :param config: Configuration object, defaults to creating from envvars
+    :type config: Config, optional
+    """
+    client = ContainerInstanceManagementClient(credential, config.subscription_id)
+    try:
+        client.container_groups.begin_delete(config.resource_group, model_run_id)
+        print(f"Successfully deleted container group {model_run_id}")
+    except ResourceNotFoundError:
+        print(f"{model_run_id} does not exist, potentially already removed")
+
+
+def clean_up_model_run(
+    model_run_id: str,
+    credential: TokenCredential = DefaultAzureCredential(),
+    config: Config = Config.create_from_envvars(),
+) -> None:
+    """Clean up a model run.
+
+    Clean up a model run by deleting both the params file in the queue, and the compute resource
+    in ACI.
+
+    :param model_run_id: The id of the model run to delete.
+    :type model_run_id: str
+    :param credential: Credential for authenticating with Azure,
+        defaults to DefaultAzureCredential()
+    :type credential: TokenCredential, optional
+    :param config: Configuration object, defaults to creating from envvars
+    :type config: Config, optional
+    """
+    _delete_blob_in_queue(model_run_id, credential, config)
+    _delete_container_group(model_run_id, credential, config)

--- a/src/nhp/aci/run_model/__init__.py
+++ b/src/nhp/aci/run_model/__init__.py
@@ -17,7 +17,7 @@ def create_model_run(
     save_full_model_results: bool = False,
     timeout: str = "60m",
     credential: TokenCredential = DefaultAzureCredential(),
-    config=Config.create_from_envvars(),
+    config: Config = Config.create_from_envvars(),
 ) -> dict:
     """Create a model run.
 

--- a/tests/unit/nhp/aci/test___main__.py
+++ b/tests/unit/nhp/aci/test___main__.py
@@ -1,0 +1,383 @@
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+
+from nhp.aci.__main__ import _arg_parser, _run, _status, main
+
+
+class TestArgParser:
+    class TestRun:
+        def test_defaults(self):
+            parser = _arg_parser()
+            args = parser.parse_args(
+                [
+                    "run",
+                    "id",
+                ]
+            )
+
+            assert args.command == "run"
+            assert args.params == "id"
+            assert args.app_version is None
+            assert args.dataset is None
+            assert not args.save_full_model_results
+            assert args.timeout == "60m"
+
+        def test_app_version(self):
+            parser = _arg_parser()
+            args = parser.parse_args(["run", "id", "--app-version", "dev"])
+
+            assert args.command == "run"
+            assert args.params == "id"
+            assert args.app_version == "dev"
+            assert args.dataset is None
+            assert not args.save_full_model_results
+            assert args.timeout == "60m"
+
+        def test_dataset(self):
+            parser = _arg_parser()
+            args = parser.parse_args(["run", "id", "--dataset", "dataset"])
+
+            assert args.command == "run"
+            assert args.params == "id"
+            assert args.app_version is None
+            assert args.dataset == "dataset"
+            assert not args.save_full_model_results
+            assert args.timeout == "60m"
+
+        def test_save_full_model_results(self):
+            parser = _arg_parser()
+            args = parser.parse_args(["run", "id", "--save-full-model-results"])
+
+            assert args.command == "run"
+            assert args.params == "id"
+            assert args.app_version is None
+            assert args.dataset is None
+            assert args.save_full_model_results
+            assert args.timeout == "60m"
+
+        def test_timeout(self):
+            parser = _arg_parser()
+            args = parser.parse_args(["run", "id", "--timeout", "30m"])
+
+            assert args.command == "run"
+            assert args.params == "id"
+            assert args.app_version is None
+            assert args.dataset is None
+            assert not args.save_full_model_results
+            assert args.timeout == "30m"
+
+    class TestStatus:
+        def test_with_model_id(self):
+            parser = _arg_parser()
+            args = parser.parse_args(
+                [
+                    "status",
+                    "id",
+                ]
+            )
+
+            assert args.command == "status"
+            assert args.model_id == "id"
+
+        def test_without_model_id(self):
+            parser = _arg_parser()
+            args = parser.parse_args(
+                [
+                    "status",
+                ]
+            )
+
+            assert args.command == "status"
+            assert args.model_id is None
+
+    class TestClean:
+        def test_with_model_id(self):
+            parser = _arg_parser()
+            args = parser.parse_args(
+                [
+                    "clean",
+                    "id",
+                ]
+            )
+
+            assert args.command == "clean"
+            assert args.model_id == "id"
+
+
+class TestRun:
+    def test_just_params_file_with_app_version_in_params(self, mocker):
+        # arrange
+        args = Mock()
+        args.params = "file.json"
+        args.save_full_model_results = False
+        args.timeout = "60m"
+        args.app_version = None
+        args.dataset = None
+
+        m_open = mock_open(read_data='{"app_version": "v1"}')
+
+        m_create = mocker.patch("nhp.aci.__main__.create_model_run", return_value={"id": "id"})
+
+        m_print = mocker.patch("builtins.print")
+
+        # act
+        with patch("builtins.open", m_open):
+            _run(args)
+
+        # assert
+        m_open.assert_called_once_with("file.json", "r", encoding="UTF-8")
+        m_create.assert_called_once_with({"app_version": "v1"}, "v1", False, "60m")
+        m_print.assert_called_once_with("Model run started: id")
+
+    def test_just_params_file_without_app_version_in_params(self, mocker):
+        # arrange
+        args = Mock()
+        args.params = "file.json"
+        args.save_full_model_results = False
+        args.timeout = "60m"
+        args.app_version = None
+        args.dataset = None
+
+        m_open = mock_open(read_data="{}")
+
+        m_create = mocker.patch("nhp.aci.__main__.create_model_run", return_value={"id": "id"})
+
+        m_print = mocker.patch("builtins.print")
+
+        # act
+        with patch("builtins.open", m_open):
+            _run(args)
+
+        # assert
+        m_open.assert_called_once_with("file.json", "r", encoding="UTF-8")
+        m_create.assert_called_once_with({"app_version": "dev"}, "dev", False, "60m")
+        m_print.assert_called_once_with("Model run started: id")
+
+    def test_setting_app_version(self, mocker):
+        # arrange
+        args = Mock()
+        args.params = "file.json"
+        args.save_full_model_results = False
+        args.timeout = "60m"
+        args.app_version = "v2"
+        args.dataset = None
+
+        m_open = mock_open(read_data="{}")
+
+        m_create = mocker.patch("nhp.aci.__main__.create_model_run", return_value={"id": "id"})
+
+        m_print = mocker.patch("builtins.print")
+
+        # act
+        with patch("builtins.open", m_open):
+            _run(args)
+
+        # assert
+        m_open.assert_called_once_with("file.json", "r", encoding="UTF-8")
+        m_create.assert_called_once_with({"app_version": "v2"}, "v2", False, "60m")
+        m_print.assert_called_once_with("Model run started: id")
+
+    def test_setting_dataset(self, mocker):
+        # arrange
+        args = Mock()
+        args.params = "file.json"
+        args.save_full_model_results = False
+        args.timeout = "60m"
+        args.app_version = None
+        args.dataset = "dataset"
+
+        m_open = mock_open(read_data="{}")
+
+        m_create = mocker.patch("nhp.aci.__main__.create_model_run", return_value={"id": "id"})
+
+        m_print = mocker.patch("builtins.print")
+
+        # act
+        with patch("builtins.open", m_open):
+            _run(args)
+
+        # assert
+        m_open.assert_called_once_with("file.json", "r", encoding="UTF-8")
+        m_create.assert_called_once_with(
+            {"app_version": "dev", "dataset": "dataset"}, "dev", False, "60m"
+        )
+        m_print.assert_called_once_with("Model run started: id")
+
+
+class TestStatus:
+    @pytest.mark.parametrize(
+        "complete, expected",
+        [
+            (
+                {"aae": 1, "outpatients": 100, "inpatients": 100},
+                "aae: 1",
+            ),
+            (
+                {"aae": 0, "outpatients": 2, "inpatients": 100},
+                "op: 2",
+            ),
+            (
+                {"aae": 0, "outpatients": 0, "inpatients": 3},
+                "ip: 3",
+            ),
+        ],
+    )
+    def test_single_model_run_exists(self, mocker, complete, expected):
+        # arrange
+        status = {"state": "running", "complete": complete, "model_runs": 100}
+        m_status = mocker.patch("nhp.aci.__main__.get_model_run_status", return_value=status)
+        args = Mock()
+        args.model_id = "id"
+        m_print = mocker.patch("builtins.print")
+
+        # act
+        _status(args)
+
+        # assert
+        m_status.assert_called_once_with("id")
+        m_print.assert_called_once_with(f"id: running [{expected}/100]")
+
+    def test_single_model_run_not_exists(self, mocker):
+        # arrange
+        m_status = mocker.patch("nhp.aci.__main__.get_model_run_status", return_value=None)
+        args = Mock()
+        args.model_id = "id"
+        m_print = mocker.patch("builtins.print")
+
+        # act
+        _status(args)
+
+        # assert
+        m_status.assert_called_once_with("id")
+        m_print.assert_called_once_with("Unknown model id: id")
+
+    def test_all_model_runs_no_runs(self, mocker):
+        # arrange
+        m_cmr = mocker.patch("nhp.aci.__main__.get_current_model_runs", return_value={})
+        args = Mock()
+        args.model_id = None
+        m_print = mocker.patch("builtins.print")
+
+        # act
+        _status(args)
+
+        # assert
+        m_cmr.assert_called_once()
+        m_print.assert_called_once_with("There are currently no model runs")
+
+    def test_all_model_runs_with_runs(self, mocker):
+        # arrange
+        m_cmr = mocker.patch(
+            "nhp.aci.__main__.get_current_model_runs",
+            return_value={"a": {"state": "running"}, "b": {"state": "terminated"}, "c": {}},
+        )
+        args = Mock()
+        args.model_id = None
+
+        print_output = []
+        m_print = mocker.patch("builtins.print", side_effect=lambda x: print_output.append(x))
+
+        # act
+        _status(args)
+
+        # assert
+        m_cmr.assert_called_once()
+        assert m_print.call_count == 4
+        assert print_output == ["Current Model Runs:", "a: running", "b: terminated", "c: unknown"]
+
+
+class TestMain:
+    def test_run(self, mocker):
+        # arrange
+        m = mocker.patch("nhp.aci.__main__._arg_parser")
+        m().parse_args().command = "run"
+        m.reset_mock()
+
+        m_run = mocker.patch("nhp.aci.__main__._run")
+        m_status = mocker.patch("nhp.aci.__main__._status")
+        m_clean = mocker.patch("nhp.aci.__main__.clean_up_model_run")
+
+        # act
+        main()
+
+        # assert
+        m.assert_called_once()
+        m_run.assert_called_once_with(m().parse_args())
+        m_status.assert_not_called()
+        m_clean.assert_not_called()
+        m().print_help.assert_not_called()
+
+    def test_status(self, mocker):
+        # arrange
+        m = mocker.patch("nhp.aci.__main__._arg_parser")
+        m().parse_args().command = "status"
+        m.reset_mock()
+
+        m_run = mocker.patch("nhp.aci.__main__._run")
+        m_status = mocker.patch("nhp.aci.__main__._status")
+        m_clean = mocker.patch("nhp.aci.__main__.clean_up_model_run")
+
+        # act
+        main()
+
+        # assert
+        m.assert_called_once()
+        m_run.assert_not_called()
+        m_status.assert_called_once_with(m().parse_args())
+        m_clean.assert_not_called()
+        m().print_help.assert_not_called()
+
+    def test_clean(self, mocker):
+        # arrange
+        m = mocker.patch("nhp.aci.__main__._arg_parser")
+        m().parse_args().command = "clean"
+        m().parse_args().model_id = "id"
+        m.reset_mock()
+
+        m_run = mocker.patch("nhp.aci.__main__._run")
+        m_status = mocker.patch("nhp.aci.__main__._status")
+        m_clean = mocker.patch("nhp.aci.__main__.clean_up_model_run")
+
+        # act
+        main()
+
+        # assert
+        m.assert_called_once()
+        m_run.assert_not_called()
+        m_status.assert_not_called()
+        m_clean.assert_called_once_with("id")
+        m().print_help.assert_not_called()
+
+    def test_help(self, mocker):
+        # arrange
+        m = mocker.patch("nhp.aci.__main__._arg_parser")
+        m().parse_args().command = "UNKNOWN COMMAND"
+        m.reset_mock()
+
+        m_run = mocker.patch("nhp.aci.__main__._run")
+        m_status = mocker.patch("nhp.aci.__main__._status")
+        m_clean = mocker.patch("nhp.aci.__main__.clean_up_model_run")
+
+        # act
+        main()
+
+        # assert
+        m.assert_called_once()
+        m_run.assert_not_called()
+        m_status.assert_not_called()
+        m_clean.assert_not_called()
+        m().print_help.assert_called_once()
+
+
+def test_init(mocker):
+    main_mock = mocker.patch("nhp.aci.__main__.main")
+
+    import nhp.aci.__main__ as m
+
+    m.init()
+    main_mock.assert_not_called()
+
+    with patch.object(m, "__name__", "__main__"):
+        m.init()
+        main_mock.assert_called_once()

--- a/tests/unit/nhp/aci/test_clean_up.py
+++ b/tests/unit/nhp/aci/test_clean_up.py
@@ -1,0 +1,98 @@
+from unittest.mock import Mock
+
+from azure.core.exceptions import ResourceNotFoundError
+
+from nhp.aci.clean_up import _delete_blob_in_queue, _delete_container_group, clean_up_model_run
+
+
+def test_delete_blob_in_queue(mocker):
+    # arrange
+    m = mocker.patch("nhp.aci.clean_up.BlobServiceClient")
+
+    print_mock = mocker.patch("builtins.print")
+
+    config = Mock()
+    config.storage_endpoint = "ep"
+
+    # act
+    _delete_blob_in_queue("id", "credential", config)  # type: ignore
+
+    # assert
+    m.assert_called_once_with("ep", "credential")
+    m().get_container_client.assert_called_once_with("queue")
+    m().get_container_client().delete_blob.assert_called_once_with("id.json")
+    print_mock.assert_called_once_with("Successfully deleted id.json from queue")
+
+
+def test_delete_blob_in_queue_not_found(mocker):
+    # arrange
+    m = mocker.patch("nhp.aci.clean_up.BlobServiceClient")
+    m().get_container_client().delete_blob.side_effect = ResourceNotFoundError()
+    m.reset_mock()
+
+    print_mock = mocker.patch("builtins.print")
+
+    config = Mock()
+    config.storage_endpoint = "ep"
+
+    # act
+    _delete_blob_in_queue("id", "credential", config)  # type: ignore
+
+    # assert
+    m.assert_called_once_with("ep", "credential")
+    m().get_container_client.assert_called_once_with("queue")
+    m().get_container_client().delete_blob.assert_called_once_with("id.json")
+    print_mock.assert_called_once_with("id.json does not exist, potentially already removed")
+
+
+def test_delete_container_group(mocker):
+    # arrange
+    m = mocker.patch("nhp.aci.clean_up.ContainerInstanceManagementClient")
+
+    print_mock = mocker.patch("builtins.print")
+
+    config = Mock()
+    config.resource_group = "resource_group"
+    config.subscription_id = "subscription_id"
+
+    # act
+    _delete_container_group("id", "credential", config)  # type: ignore
+
+    # assert
+    m.assert_called_once_with("credential", "subscription_id")
+    m().container_groups.begin_delete.assert_called_once_with("resource_group", "id")
+    print_mock.assert_called_once_with("Successfully deleted container group id")
+
+
+def test_delete_container_group_not_found(mocker):
+    # arrange
+    m = mocker.patch("nhp.aci.clean_up.ContainerInstanceManagementClient")
+    m().container_groups.begin_delete.side_effect = ResourceNotFoundError()
+    m.reset_mock()
+
+    print_mock = mocker.patch("builtins.print")
+
+    config = Mock()
+    config.resource_group = "resource_group"
+    config.subscription_id = "subscription_id"
+
+    # act
+    _delete_container_group("id", "credential", config)  # type: ignore
+
+    # assert
+    m.assert_called_once_with("credential", "subscription_id")
+    m().container_groups.begin_delete.assert_called_once_with("resource_group", "id")
+    print_mock.assert_called_once_with("id does not exist, potentially already removed")
+
+
+def test_clean_up_model_run(mocker):
+    # arrange
+    m1 = mocker.patch("nhp.aci.clean_up._delete_blob_in_queue")
+    m2 = mocker.patch("nhp.aci.clean_up._delete_container_group")
+
+    # act
+    clean_up_model_run("id", "credential", "config")  # type: ignore
+
+    # assert
+    m1.assert_called_once_with("id", "credential", "config")
+    m2.assert_called_once_with("id", "credential", "config")


### PR DESCRIPTION
implements following commands:
* run, expects the name of a parameters file. allows some simple overriding of values in the the params file (app version and dataset)
* status, can take a model run id and give the status for a specific model run, or if no model id given will show status of all current model runs
* clean, takes a model run id and removes the file in the queue container and the container group in aci
